### PR TITLE
Set `network.host` instead of `network.bind_host`

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,3 +1,3 @@
 cluster.name: "elastic"
 # bind to all network interfaces
-network.bind_host: 0.0.0.0
+network.host: 0.0.0.0


### PR DESCRIPTION
`bind_host` takes its value from `network.host`, which by default is now set to localhost.